### PR TITLE
Query scanner refactor

### DIFF
--- a/app/scanners/query_scanner.rb
+++ b/app/scanners/query_scanner.rb
@@ -2,25 +2,34 @@ class QueryScanner
   ALLOWED_KEYWORDS = %w(
     all first find find_by group having joins last
     left_outer_joins order offset select unscope where
-    limit pluck count avg as asc desc average
-    CASE WHEN THEN ELSE END
+    limit pluck count avg as asc desc average min max
+    case when then else end
   ).to_set
 
-  NON_KEYWORD_CHARS = %w(" ' :).to_set
   attr_reader :errors
 
   def default_model_names
-    %w(Student Course Enrollment Teacher)
+    %w(student course enrollment teacher)
   end
 
   def allowed_column_names
-    %w(grade id room_number name av_grade highest_grade)
+    %w(grade id room_number name level)
+  end
+
+  def allowed_miscellaneous
+    %w(rails magic)
+  end
+
+  def column_ids
+    default_model_names.map{|name| name + '_id'}
   end
 
   def allowed_db_names
     default_model_names +
     default_model_names.map{|name| name.downcase + 's'} +
-    allowed_column_names
+    allowed_column_names +
+    column_ids +
+    allowed_miscellaneous
   end
 
   def initialize(code = nil, db_names = allowed_db_names)
@@ -50,9 +59,28 @@ class QueryScanner
   end
 
   def keywords
-    split_words.reject do |word|
-      NON_KEYWORD_CHARS.include?(word[0]) || NON_KEYWORD_CHARS.include?(word[-1]) || word =~ /^\d+$/
+    result = []
+    split_words.each do |word|
+      next if result[-1] == 'as'
+      next if word_in_quotes?(word)
+      word = word_characters_only(word)
+      next if just_numbers?(word)
+      result << word.downcase
     end
+    result
+  end
+
+  def word_characters_only(word)
+    word.gsub(/\W/, '')
+  end
+
+  def word_in_quotes?(word)
+    quote_marks = %w(' ")
+    quote_marks.include?(word[0]) && word[-1] == word[0]
+  end
+
+  def just_numbers?(word)
+    word =~ /^\d+$/ ? true : false
   end
 
   def unpermitted_keywords

--- a/app/views/exercises/show.html.haml
+++ b/app/views/exercises/show.html.haml
@@ -51,7 +51,7 @@
 
 - unless @show_answer
   %p
-    = button_to('', surrender_path(@exercise), {id: 'surrender-button', data: {confirm: "Choosing to look at our answer means you won't be able to get credit for completing this exercise for another 24 hours. Are you sure you want to peak?"}})
+    = button_to('', surrender_path(@exercise), {id: 'surrender-button', data: {confirm: "Choosing to look at our answer means you won't be able to get credit for completing this exercise for another 24 hours. Are you sure you want to peek?"}})
 
 - if @show_answer
   #answers-and-discussion

--- a/spec/features/user/exercise_credit_blocked_spec.rb
+++ b/spec/features/user/exercise_credit_blocked_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 describe 'exercise index page' do
-  it 'when I peak at an exercise, this is indicated. I am not able to get credit for completing it until 24 hours pass.' do
+  it 'when I peek at an exercise, this is indicated. I am not able to get credit for completing it until 24 hours pass.' do
     extra_user = create(:user)
     ex1 = create(:exercise, index: 1)
     TimedBlock.create(user: extra_user, exercise: ex1, expiration: 2.days.from_now )

--- a/spec/features/user/exercise_show_spec.rb
+++ b/spec/features/user/exercise_show_spec.rb
@@ -40,12 +40,12 @@ describe 'excercise show page' do
       visit exercise_path(exercise)
     end
     scenario 'a basic syntax error' do
-      @solution = "Student.where(price: 98"
+      @solution = "Student.where(name: 98"
       @error = "syntax error, unexpected end-of-input, expecting ')'"
     end
     scenario 'a column that does not exist' do
       @solution = "Student.where(dragon: 'puff')"
-      @error = "ERROR: column students.dragon does not exist"
+      @error = "Security : Only activerecord queries will be executed : `dragon` not permitted"
     end
     after(:each) do
       fill_in :solution_solution_code, with: @solution
@@ -83,7 +83,7 @@ describe 'excercise show page' do
       @error = "Only activerecord queries will be executed : `binding`, `pry` not permitted"
     end
     it "such as `create`" do
-      fill_in :solution_solution_code, with: "Student.create(name: 'Mr. Robot')"
+      fill_in :solution_solution_code, with: "Student.create(name: 'MrRobot')"
       @error = "Only activerecord queries will be executed : `create` not permitted"
     end
     scenario "such as `destroy_all`" do

--- a/spec/features/user/solutions_run_spec.rb
+++ b/spec/features/user/solutions_run_spec.rb
@@ -10,7 +10,7 @@ describe 'there are no errors' do
     "Enrollment.where('grade >= 60')",
     "Enrollment.where('grade < 60').count",
     "Enrollment.where(student_id: [1])",
-    "Enrollment.where(course_id: [1, 9])",
+    "Course.where(teacher_id: [1, 9])",
     "Course.joins(:enrollments).group(:id).order('count(enrollments) desc')",
     "Course.order(level: :asc).limit(3).pluck(:name)",
     "Student.joins(enrollments: :course).where(courses: {name: 'Rails Magic'})",

--- a/spec/scanners/query_scanner_spec.rb
+++ b/spec/scanners/query_scanner_spec.rb
@@ -10,6 +10,6 @@ describe QueryScanner do
   it '.keywords' do
     qs = QueryScanner.new
     qs.scan("Student.where(dragon: 'puff')")
-    expect(qs.send(:keywords)).to eq(%w(Student where))
+    expect(qs.send(:keywords)).to eq(%w(Student where dragon))
   end
 end


### PR DESCRIPTION
After realizing that 'max' was considered a key word in certain contexts but not in others, I decided to refactor the query scanner.

Now, words have a colon to either side, and multiple words inside quotes are considered keywords and checked against the keyword list accordingly. Single words inside quotes are still ignored, as well as words that are just numbers.