### PR TITLE
Plurals and partials

### DIFF
--- a/app/views/exercises/_exercise_nav.html.haml
+++ b/app/views/exercises/_exercise_nav.html.haml
@@ -1,0 +1,8 @@
+.exercise-nav
+  = link_to("All Exercises", exercises_path)
+  - if @exercise.index > Exercise.minimum_index
+    |
+    = link_to("Previous Exercise", exercise_path(Exercise.find_by(index: @exercise.index - 1)))
+  |
+  - if @exercise.index < Exercise.maximum_index
+    = link_to("Next Exercise", exercise_path(Exercise.find_by(index: @exercise.index + 1)))

--- a/app/views/exercises/_exercise_title.html.haml
+++ b/app/views/exercises/_exercise_title.html.haml
@@ -1,4 +1,4 @@
 %li{:id => "exercise-#{exercise.id}"}
   = link_to exercise.name, exercise_path(exercise)
   - if current_user && current_user.completed?(exercise)
-    = "Completed #{current_user.times_completed(exercise)} times"
+    = "Completed " + pluralize(current_user.times_completed(exercise), 'time')

--- a/app/views/exercises/show.html.haml
+++ b/app/views/exercises/show.html.haml
@@ -1,11 +1,5 @@
 #top-exercise-nav
-  = link_to("All Exercises", exercises_path)
-  - if @exercise.index > Exercise.minimum_index
-    |
-    = link_to("Previous Exercise", exercise_path(Exercise.find_by(index: @exercise.index - 1)))
-  |
-  - if @exercise.index < Exercise.maximum_index
-    = link_to("Next Exercise", exercise_path(Exercise.find_by(index: @exercise.index + 1)))
+  = render partial: 'exercises/exercise_nav', locals: {exercise: @exercise}
 
 = image_tag(asset_path('school_tables.jpg'), id: 'db-tables')
 
@@ -63,10 +57,4 @@
       = @exercise.notes
     %br
 
-
-#bottom-exercise-nav
-  - if @exercise.index > Exercise.minimum_index
-    = link_to("Previous Exercise", exercise_path(Exercise.find_by(index: @exercise.index - 1)))
-  |
-  - if @exercise.index < Exercise.maximum_index
-    = link_to("Next Exercise", exercise_path(Exercise.find_by(index: @exercise.index + 1)))
+= render partial: 'exercises/exercise_nav', locals: {exercise: @exercise}

--- a/spec/features/guest/exercise_show_next_and_previous_spec.rb
+++ b/spec/features/guest/exercise_show_next_and_previous_spec.rb
@@ -7,10 +7,7 @@ describe 'the next and previous links on the exercise show page' do
       expect(page).to have_content('Next Exercise')
       expect(page).to have_content('Previous Exercise')
     end
-    within "#bottom-exercise-nav" do
-      expect(page).to have_content('Next Exercise')
-      expect(page).to have_content('Previous Exercise')
-    end
+    expect(page).to have_css('.exercise-nav', count: 2)
   end
   it 'the next link takes you the next exercise' do
     ex1 = create(:exercise, index: 1)
@@ -20,24 +17,12 @@ describe 'the next and previous links on the exercise show page' do
       click_on('Next Exercise')
     end
     expect(current_path).to eq(exercise_path(ex2))
-
-    visit exercise_path(ex1)
-    within "#bottom-exercise-nav" do
-      click_on('Next Exercise')
-    end
-    expect(current_path).to eq(exercise_path(ex2))
   end
   it 'the previous link takes you the previous exercise' do
     ex1 = create(:exercise, index: 1)
     ex2 = create(:exercise, index: 2)
     visit exercise_path(ex2)
     within "#top-exercise-nav" do
-      click_on('Previous Exercise')
-    end
-    expect(current_path).to eq(exercise_path(ex1))
-
-    visit exercise_path(ex2)
-    within "#bottom-exercise-nav" do
       click_on('Previous Exercise')
     end
     expect(current_path).to eq(exercise_path(ex1))

--- a/spec/features/user/exercise_completion_spec.rb
+++ b/spec/features/user/exercise_completion_spec.rb
@@ -20,7 +20,7 @@ describe 'exercise index page' do
     end
     visit exercises_path
     within "#exercise-#{ex3.id}" do
-      expect(page).to have_content "Completed 1 times"
+      expect(page).to have_content "Completed 1 time"
     end
   end
   it 'when I execute an incorrect solution, it is not marked as complete' do

--- a/spec/features/user/exercise_credit_blocked_spec.rb
+++ b/spec/features/user/exercise_credit_blocked_spec.rb
@@ -37,7 +37,7 @@ describe 'exercise index page' do
     click_on 'execute'
     visit exercises_path
     within "#exercise-#{ex1.id}" do
-      expect(page).to have_content "Completed 1 times"
+      expect(page).to have_content "Completed 1 time"
     end
   end
 end

--- a/spec/features/user/exercise_index_spec.rb
+++ b/spec/features/user/exercise_index_spec.rb
@@ -31,7 +31,7 @@ describe 'exercise index page' do
     end
     within("#exercise-#{ex2.id}") do
       expect(page).to have_link(ex2.name, href: exercise_path(ex2))
-      expect(page).to have_content("Completed 1 times")
+      expect(page).to have_content("Completed 1 time")
     end
     within("#exercise-#{ex3.id}") do
       expect(page).to have_link(ex3.name, href: exercise_path(ex3))

--- a/spec/features/user/exercise_show_spec.rb
+++ b/spec/features/user/exercise_show_spec.rb
@@ -3,7 +3,9 @@ describe 'excercise show page' do
   it 'has a link back to the home page' do
     exercise = create(:exercise)
     visit exercise_path(exercise)
-    click_on('All Exercises')
+    within('#top-exercise-nav') do
+      click_on('All Exercises')
+    end
     expect(current_path).to eq(exercises_path)
   end
   it 'has the exercise name and instruction' do


### PR DESCRIPTION
Extracts exercise nav (previous and next links) into partial, adding all exercises to bottom nav, and maintaining a top-exercise-nav css id for testing purposes.

Fixes 'Completed 1 times' error with ActiveSupport's pluralize method.

All tests passing.